### PR TITLE
enrich error messages

### DIFF
--- a/cmd/helm-sealed-secrets/renderer.go
+++ b/cmd/helm-sealed-secrets/renderer.go
@@ -172,9 +172,6 @@ func dataToBase64(secretContent string) (string, error) {
 			data := item.Value.(yaml.MapSlice)
 			for k, dataItem := range data {
 				valueBytes := []byte(fmt.Sprintf("%v", dataItem.Value))
-				if err != nil {
-					return "", err
-				}
 				data[k].Value = base64.StdEncoding.EncodeToString(valueBytes)
 			}
 		}


### PR DESCRIPTION
We had some trouble to identify the file which caused problems when using the command `enc-dir`. This PR adds the name of the current processed file to the error messages.